### PR TITLE
still building end turn foundation

### DIFF
--- a/py_ferry/database.py
+++ b/py_ferry/database.py
@@ -90,6 +90,8 @@ class Ferry(Base):
     id = Column(Integer, primary_key = True)
     name = Column(String(64))
     launched = Column(DateTime)
+    # TODO turnover_time should come from the class maybe, and then based on staffing
+    turnover_time = Column(Integer)
     game_id = Column(Integer, ForeignKey('games.id'), nullable = False)
     ferry_class_id = Column(Integer, ForeignKey('ferry_classes.id'), nullable = False)
     route_id = Column(Integer, ForeignKey('routes.id'))

--- a/py_ferry/models.py
+++ b/py_ferry/models.py
@@ -1,5 +1,8 @@
 from datetime import datetime
 import random
+import math
+
+# TODO these singletons don't seem very pythonic
 
 class Fuel(object):
     ''' properties and methods related to fuel costing '''
@@ -10,11 +13,11 @@ class Fuel(object):
     def cost_per_gallon(self):
         return self.fuel_cost / self.gals_in_oil_bbl
         
-class Passengers(object):
+class Passenger(object):
     ''' passengers '''
     def __init__(self):
         self.annual_growth_rate = 1.02
-        self.week_demand = {
+        self.day_demand = {
             'Monday':
                 [
                     0.1, 0.1, 0, 0, 0, 0.3,
@@ -65,28 +68,38 @@ class Passengers(object):
                     0.8, 0.5, 0.4, 0.3, 0.2, 0.1
                 ]
         }
-        self.year_demand = {
-            'January': 0.7,
-            'February': 0.7,
-            'March': 0.7,
-            'April': 0.75,
-            'May': 0.8,
-            'June': 0.85,
-            'July': 0.95,
-            'August': 1,
-            'September': 0.95,
-            'October': 0.8,
-            'November': 0.7,
-            'December': 0.7
+        self.week_demand = {
+            1: 0.7,
+            5: 0.7,
+            9: 0.7,
+            13: 0.75,
+            17: 0.8,
+            21: 0.85,
+            25: 0.95,
+            29: 1,
+            33: 0.95,
+            37: 0.8,
+            41: 0.7,
+            45: 0.7,
+            49: 0.7,
         }
         self.base_year = 2016
         self.growth_rate = 1.025
 
-    def demand(self, day, hour, month, year):
-        base_demand = self.week_demand[day][hour] * self.year_demand[month]
+    def route_passenger_demand(self, passengers, hour, day, week, year):
+        week_floor = math.floor(week / 4 + 1)
+        base_demand = self.day_demand[day][hour] * self.week_demand[week_floor]
         offset_years = year - self.base_year
         base_demand = base_demand * (self.growth_rate ** offset_years)
-        return base_demand
+        return round(base_demand * passengers / 24)
+        
+    def week_route_passenger_demand(self, passengers, week, year):
+        route_total = 0
+        days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
+        for day in days:
+            for hour in range(0, 23):
+                route_total += self.route_passenger_demand(passengers, hour, day, week, year)
+        return route_total
         
     # days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
     # for day in days:
@@ -100,3 +113,100 @@ class Passengers(object):
     #                     print('car_queue', car_queue)
     #                     car_queue -= min(ferry.cars, car_queue)
     #                     print('loading up!', math.trunc(time), ':', str(round(time % 1 * 60)).zfill(2), end = ' ')
+    
+class Schedule(object):
+    def __init__(self):
+        self.full_staffing = {
+            'weekday': 
+                {
+                    0: True,
+                    1: False,
+                    2: False,
+                    3: False,
+                    4: False,
+                    5: True,
+                    6: True,
+                    7: True,
+                    8: True,
+                    9: True,
+                    10: True,
+                    11: True,
+                    12: True,
+                    13: True,
+                    14: True,
+                    15: True,
+                    16: True,
+                    17: True,
+                    18: True,
+                    19: True,
+                    20: True,
+                    21: True,
+                    22: True,
+                    23: True
+                },
+            'weekend':
+                {
+                    0: True,
+                    1: True,
+                    2: True,
+                    3: True,
+                    4: True,
+                    5: True,
+                    6: True,
+                    7: True,
+                    8: True,
+                    9: True,
+                    10: True,
+                    11: True,
+                    12: True,
+                    13: True,
+                    14: True,
+                    15: True,
+                    16: True,
+                    17: True,
+                    18: True,
+                    19: True,
+                    20: True,
+                    21: True,
+                    22: True,
+                    23: True
+                }
+        }
+        self.day_mapping = {
+            'Monday': 'weekday',
+            'Tuesday': 'weekday',
+            'Wednesday': 'weekday',
+            'Thursday': 'weekday',
+            'Friday': 'weekday',
+            'Saturday': 'weekend',
+            'Sunday': 'weekend',
+        }
+        
+    def route_interval(self, route):
+        return route['route_distance'] / route['ferries'][0]['speed'] + route['ferries'][0]['turnover_time']
+    
+    def first_run(self, shift_mapping):
+        for time in range(0, 23):
+            if self.full_staffing[shift_mapping][time] == True:
+                return time
+                
+    def last_run(self, shift_mapping):
+        for time in range(23, 0, -1):
+            if self.full_staffing[shift_mapping][time] == True:
+                return time
+    
+    def build_schedule(self, route, day):
+        schedule = []
+        shift_mapping = self.day_mapping[day]
+        first_shift_hour = self.first_run(shift_mapping)
+        last_shift_hour = self.last_run(shift_mapping)
+        run_interval = self.route_interval(route)
+        
+        next_time = first_shift_hour
+        while next_time < last_shift_hour:
+            if self.full_staffing[shift_mapping][int(next_time)] == True:
+                schedule.append(next_time)
+            next_time += run_interval
+        
+        return schedule
+    

--- a/tests/test_models_unit.py
+++ b/tests/test_models_unit.py
@@ -9,9 +9,31 @@ class FilterTests(unittest.TestCase):
         fuel_cost = Fuel().cost_per_gallon()
         self.assertAlmostEqual(fuel_cost, 10.17, 2)
         
+    def test_empty_passenger_demand(self):
+        with self.assertRaises(TypeError):
+            demand = Passenger().route_passenger_demand()
+        
     def test_passenger_demand(self):
-        demand = Passengers().demand('Tuesday', 7, 'October', 2016)
-        self.assertEqual(demand, 0.76)
+        demand = Passenger().route_passenger_demand(30000, 7, 'Tuesday', 3, 2016)
+        self.assertEqual(demand, 831)
+    
+    def test_week_passenger_demand(self):
+        demand = Passenger().week_route_passenger_demand(30000, 3, 2016)
+        self.assertEqual(demand, 65454)
+        
+    def test_build_schedule(self):
+        route = {
+            'route_distance': 7.1,
+            'ferries': [
+                    {
+                        'speed': 18,
+                        'turnover_time': 0.2
+                    }
+                ]
+        }
+        expected_schedule = [0, 0.5944444444444444, 5.35, 5.944444444444444, 6.538888888888888, 7.133333333333332, 7.727777777777776, 8.322222222222221, 8.916666666666666, 9.511111111111111, 10.105555555555556, 10.700000000000001, 11.294444444444446, 11.888888888888891, 12.483333333333336, 13.077777777777781, 13.672222222222226, 14.266666666666671, 14.861111111111116, 15.455555555555561, 16.050000000000004, 16.64444444444445, 17.238888888888894, 17.83333333333334, 18.427777777777784, 19.02222222222223, 19.616666666666674, 20.21111111111112, 20.805555555555564, 21.40000000000001, 21.994444444444454, 22.5888888888889]
+        schedule = Schedule().build_schedule(route, 'Monday')
+        self.assertEqual(schedule, expected_schedule)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
change name of week_demand to day_demand
add week_demand to replace year_demand to store key->value pairs of week numbers and demand multipliers
adjust demand method and test result to match
rename demand to route_passenger_demand and have the method return the actual passenger demand and not the base_demand; update test
refactor handling of week_demand so that it uses the floor of values based on week numbers
add schedule class
add turnover_time for ferry
build schedule builder based on shift schedule
