### PR TITLE
some very specific work on the crossings model

### DIFF
--- a/tests/test_models_unit.py
+++ b/tests/test_models_unit.py
@@ -17,13 +17,20 @@ class FilterTests(unittest.TestCase):
         demand = Passenger().route_passenger_demand(30000, 7, 'Tuesday', 3, 2016)
         self.assertEqual(demand, 831)
     
-    def test_week_passenger_demand(self):
-        demand = Passenger().week_route_passenger_demand(30000, 3, 2016)
-        self.assertEqual(demand, 65454)
+    # this is unnecessary because we'll get deamnd for each crossing
+    # def test_week_passenger_demand(self):
+    #     demand = Passenger().week_route_passenger_demand(30000, 3, 2016)
+    #     self.assertEqual(demand, 65454)
         
     def test_build_schedule(self):
         route = {
             'route_distance': 7.1,
+            'first_terminal': {
+                'id': 1
+            },
+            'second_terminal': {
+                'id': 2
+            },
             'ferries': [
                     {
                         'speed': 18,
@@ -31,9 +38,59 @@ class FilterTests(unittest.TestCase):
                     }
                 ]
         }
-        expected_schedule = [0, 0.5944444444444444, 5.35, 5.944444444444444, 6.538888888888888, 7.133333333333332, 7.727777777777776, 8.322222222222221, 8.916666666666666, 9.511111111111111, 10.105555555555556, 10.700000000000001, 11.294444444444446, 11.888888888888891, 12.483333333333336, 13.077777777777781, 13.672222222222226, 14.266666666666671, 14.861111111111116, 15.455555555555561, 16.050000000000004, 16.64444444444445, 17.238888888888894, 17.83333333333334, 18.427777777777784, 19.02222222222223, 19.616666666666674, 20.21111111111112, 20.805555555555564, 21.40000000000001, 21.994444444444454, 22.5888888888889]
+        expected_schedule = [{'arrives': {'id': 2}, 'time': 0, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 0.5944444444444444, 'departs': {'id': 2}}, {'arrives': {'id': 1}, 'time': 5.35, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 5.944444444444444, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 6.538888888888888, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 7.133333333333332, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 7.727777777777776, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 8.322222222222221, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 8.916666666666666, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 9.511111111111111, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 10.105555555555556, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 10.700000000000001, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 11.294444444444446, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 11.888888888888891, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 12.483333333333336, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 13.077777777777781, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 13.672222222222226, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 14.266666666666671, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 14.861111111111116, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 15.455555555555561, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 16.050000000000004, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 16.64444444444445, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 17.238888888888894, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 17.83333333333334, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 18.427777777777784, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 19.02222222222223, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 19.616666666666674, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 20.21111111111112, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 20.805555555555564, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 21.40000000000001, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 21.994444444444454, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 22.5888888888889, 'departs': {'id': 1}}]
         schedule = Schedule().build_schedule(route, 'Monday')
         self.assertEqual(schedule, expected_schedule)
+
+    def test_daily_crossings(self):
+        route = {
+            'route_distance': 7.1,
+            'first_terminal': {
+                'id': 1,
+                'passenger_pool': 30000,
+            },
+            'second_terminal': {
+                'id': 2,
+                'passenger_pool': 30000,
+            },
+            'ferries': [
+                    {
+                        'speed': 18,
+                        'turnover_time': 0.2,
+                        'ferry_class': {
+                            'passengers': 2500
+                        }
+                        
+                    }
+                ]
+        }
+        passengers = Sailings().daily_crossings(route, 'Tuesday', 7, 2016)
+        self.assertEqual(passengers, 19076)
+        
+    def test_weekly_crossings(self):
+        route = {
+            'route_distance': 7.1,
+            'first_terminal': {
+                'id': 1,
+                'passenger_pool': 30000,
+            },
+            'second_terminal': {
+                'id': 2,
+                'passenger_pool': 30000,
+            },
+            'ferries': [
+                    {
+                        'speed': 18,
+                        'turnover_time': 0.2,
+                        'ferry_class': {
+                            'passengers': 2500
+                        }
+                        
+                    }
+                ]
+        }
+        passengers = Sailings().weekly_crossings(route, 7, 2016)
+        self.assertEqual(passengers, 130908)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
add arrives and departs to store terminals in schedule
comment out week_route_passenger_demand because we will be iterating through weeks in the Sailings class with a new method
change mapping of week_floor for demand lookup
refactor Schedule class so that arriving and departing terminals are assigned
add Sailings class with a daily_crossings method and a weekly_crossings method so we can continue to work towards getting accumulated data for end turn
update and add tests for the crossings calculations
