### PR TITLE
a major refactoring from being unable to substitute dictionaries for classes

### DIFF
--- a/data.json
+++ b/data.json
@@ -56,7 +56,7 @@
                 "name": "Evergreen State",
                 "passengers": 854,
                 "cars": 87,
-                "tall_spaces": 30,
+                "trucks": 30,
                 "speed": 13,
                 "burn_rate": 350,
                 "cost": 80000000,

--- a/py_ferry/api.py
+++ b/py_ferry/api.py
@@ -116,9 +116,20 @@ def games_endturn(game_id):
     if not game.player == current_user:
         data = {'message': 'The game ID for the request does not belong to the current user.'}
         return Response(data, 403, mimetype = 'application/json')
-        
     
-    turn_result = database.Turn_Result(game = game, week_number = game.current_week)
+    routes = session.query(database.Route).filter(game == game)
+    
+    route = routes[0]
+    
+    weekly_results = models.Financial_Calc().calc_weekly_results_for_route(
+        route, game.current_week, game.current_year
+    )
+        
+    turn_result = database.Turn_Result(
+        game = game,
+        week_number = game.current_week,
+        total_passengers = weekly_results['passengers']
+    )
     session.add(turn_result)
     
     game.current_week += 1

--- a/py_ferry/database.py
+++ b/py_ferry/database.py
@@ -56,6 +56,7 @@ class Ferry_Class(Base):
             "trucks": self.trucks,
             "speed": self.speed,
             "burn_rate": self.burn_rate,
+            "turnover_time": self.turnover_time,
         }
     
     id = Column(Integer, primary_key = True)
@@ -68,6 +69,7 @@ class Ferry_Class(Base):
     cost = Column(Integer) # acquisition cost
     residual_value = Column(Integer) # minimum asset value
     usable_life = Column(Integer)
+    turnover_time = Column(Integer)
     
     ferry = relationship('Ferry', backref = 'ferry_class')
 
@@ -90,8 +92,6 @@ class Ferry(Base):
     id = Column(Integer, primary_key = True)
     name = Column(String(64))
     launched = Column(DateTime)
-    # TODO turnover_time should come from the class maybe, and then based on staffing
-    turnover_time = Column(Integer)
     game_id = Column(Integer, ForeignKey('games.id'), nullable = False)
     ferry_class_id = Column(Integer, ForeignKey('ferry_classes.id'), nullable = False)
     route_id = Column(Integer, ForeignKey('routes.id'))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,8 +2,6 @@ import os, sys
 
 try:
     if not os.environ['CONFIG_PATH'] == 'py_ferry.config.TestingConfig':
-        print('Environment not set: run tests by executing `python manage.py test`')
-        sys.exit(1)
+        sys.exit('Environment not set: run tests by executing `python manage.py test`')
 except:
-    print('Environment not set: run tests by executing "python manage.py test"')
-    sys.exit(1)
+    sys.exit('Environment not set: run tests by executing `python manage.py test`')

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -267,11 +267,14 @@ class TestAPI(unittest.TestCase):
         game = database.Game(player = self.user)
         
         # create terminals
-        seattle = database.Terminal(name = 'Seattle', lat = 47.6025001, lon = -122.33857590000002)
-        bainbridge_island = database.Terminal(name = 'Bainbridge Island', lat = 47.623089, lon = -122.511171)
+        seattle = database.Terminal(name = 'Seattle', lat = 47.6025001, lon = -122.33857590000002, passenger_pool = 13000, car_pool = 2000, truck_pool = 300)
+        bainbridge_island = database.Terminal(name = 'Bainbridge Island', lat = 47.623089, lon = -122.511171, passenger_pool = 13000, car_pool = 2000, truck_pool = 300)
         
         # create route
-        route = database.Route(game = game, first_terminal = seattle, second_terminal = bainbridge_island)
+        route = database.Route(
+            game = game, first_terminal = seattle, second_terminal = bainbridge_island,
+            passenger_fare = 8, car_fare = 18, truck_fare = 50
+        )
         
         # TODO ferry_class_props should be moved outside of this function as it duplicates an object for another test
         # create a ferry class
@@ -281,7 +284,8 @@ class TestAPI(unittest.TestCase):
             'cars': 202,
             'trucks': 60,
             'speed': 21,
-            'burn_rate': 350
+            'burn_rate': 350,
+            'turnover_time': 0.2,
         }
         ferry_class_A = database.Ferry_Class(
             name = ferry_class_props['name'],
@@ -290,6 +294,7 @@ class TestAPI(unittest.TestCase):
             trucks = ferry_class_props['trucks'],
             speed = ferry_class_props['speed'],
             burn_rate = ferry_class_props['burn_rate'],
+            turnover_time = ferry_class_props['turnover_time'],
         )
         
         ferry = database.Ferry(game = game, ferry_class = ferry_class_A, route = route)

--- a/tests/test_models_unit.py
+++ b/tests/test_models_unit.py
@@ -4,6 +4,41 @@ import unittest
 import py_ferry
 from py_ferry.models import *
 
+# define all of the test classes we're going to use
+
+class Terminal(object):
+    def __init__(self, id, passenger_pool, car_pool, truck_pool):
+        self.id = id
+        self.passenger_pool = passenger_pool
+        self.car_pool = car_pool
+        self.truck_pool = truck_pool
+
+class Ferry_Class(object):
+    def __init__(self, passengers, cars, trucks, burn_rate, speed, turnover_time):
+        self.passengers = passengers
+        self.cars = cars
+        self.trucks = trucks
+        self.burn_rate = burn_rate
+        self.speed = speed
+        self.turnover_time = turnover_time
+
+class Ferry(object):
+    def __init__(self, ferry_class):
+        self.ferry_class = ferry_class
+
+class Route(object):
+    def __init__(self, first_terminal, second_terminal, ferries, passenger_fare, car_fare, truck_fare):
+        self.first_terminal = first_terminal
+        self.second_terminal = second_terminal
+        self.ferries = ferries
+        self.passenger_fare = passenger_fare
+        self.car_fare = car_fare
+        self.truck_fare = truck_fare
+    
+    def route_distance(self):
+        return 7.1
+    
+
 class ModelTests(unittest.TestCase):
     def test_fuel_cost(self):
         fuel_cost = Fuel().cost_per_gallon()
@@ -18,136 +53,100 @@ class ModelTests(unittest.TestCase):
         self.assertEqual(demand, 831)
         
     def test_build_schedule(self):
-        route = {
-            'route_distance': 7.1,
-            'first_terminal': {
-                'id': 1
-            },
-            'second_terminal': {
-                'id': 2
-            },
-            'ferries': [
-                    {
-                        'speed': 18,
-                        'turnover_time': 0.2
-                    }
-                ]
-        }
-        expected_schedule = [{'arrives': {'id': 2}, 'time': 0, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 0.5944444444444444, 'departs': {'id': 2}}, {'arrives': {'id': 1}, 'time': 5.35, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 5.944444444444444, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 6.538888888888888, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 7.133333333333332, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 7.727777777777776, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 8.322222222222221, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 8.916666666666666, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 9.511111111111111, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 10.105555555555556, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 10.700000000000001, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 11.294444444444446, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 11.888888888888891, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 12.483333333333336, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 13.077777777777781, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 13.672222222222226, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 14.266666666666671, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 14.861111111111116, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 15.455555555555561, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 16.050000000000004, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 16.64444444444445, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 17.238888888888894, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 17.83333333333334, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 18.427777777777784, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 19.02222222222223, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 19.616666666666674, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 20.21111111111112, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 20.805555555555564, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 21.40000000000001, 'departs': {'id': 1}}, {'arrives': {'id': 1}, 'time': 21.994444444444454, 'departs': {'id': 2}}, {'arrives': {'id': 2}, 'time': 22.5888888888889, 'departs': {'id': 1}}]
+        ferry_class = Ferry_Class(
+            passengers = 2500, cars = 200, trucks = 60, burn_rate = 350, 
+            speed = 21, turnover_time = 0.2
+        )
+        ferry = Ferry(ferry_class = ferry_class)
+        ferries = [ferry]
+        first_terminal = Terminal(
+            id = 1, passenger_pool = 13000, car_pool = 2000, truck_pool = 300
+        )
+        second_terminal = Terminal(
+            id = 2, passenger_pool = 13000, car_pool = 2000, truck_pool = 300
+        )
+        route = Route(
+            first_terminal = first_terminal, second_terminal = second_terminal, 
+            ferries = ferries, passenger_fare = 8, car_fare = 18, truck_fare = 50
+        )
+        expected_schedule = [{'arrives': second_terminal, 'departs': first_terminal, 'time': 0}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 0.5380952380952381}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 5.3809523809523805}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 5.9190476190476184}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 6.457142857142856}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 6.995238095238094}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 7.533333333333332}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 8.071428571428571}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 8.60952380952381}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 9.147619047619047}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 9.685714285714285}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 10.223809523809523}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 10.761904761904761}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 11.299999999999999}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 11.838095238095237}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 12.376190476190475}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 12.914285714285713}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 13.45238095238095}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 13.990476190476189}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 14.528571428571427}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 15.066666666666665}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 15.604761904761903}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 16.142857142857142}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 16.68095238095238}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 17.21904761904762}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 17.757142857142856}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 18.295238095238094}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 18.833333333333332}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 19.37142857142857}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 19.909523809523808}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 20.447619047619046}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 20.985714285714284}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 21.523809523809522}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 22.06190476190476}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 22.599999999999998}]
         schedule = Schedule().build_schedule(route, 'Monday')
         self.assertEqual(schedule, expected_schedule)
 
     def test_daily_crossings(self):
-        route = {
-            'route_distance': 7.1,
-            'first_terminal': {
-                'id': 1,
-                'passenger_pool': 13000,
-                'car_pool': 2000,
-                'truck_pool': 300,
-            },
-            'second_terminal': {
-                'id': 2,
-                'passenger_pool': 13000,
-                'car_pool': 2000,
-                'truck_pool': 300,
-            },
-            'ferries': [
-                    {
-                        'speed': 18,
-                        'turnover_time': 0.2,
-                        'ferry_class': {
-                            'passengers': 2500,
-                            'cars': 200,
-                            'trucks': 60
-                        }
-                        
-                    }
-                ]
-        }
+        ferry_class = Ferry_Class(
+            passengers = 2500, cars = 200, trucks = 60, burn_rate = 350, 
+            speed = 21, turnover_time = 0.2
+        )
+        ferry = Ferry(ferry_class = ferry_class)
+        ferries = [ferry]
+        first_terminal = Terminal(
+            id = 1, passenger_pool = 13000, car_pool = 2000, truck_pool = 300
+        )
+        second_terminal = Terminal(
+            id = 2, passenger_pool = 13000, car_pool = 2000, truck_pool = 300
+        )
+        route = Route(first_terminal = first_terminal, second_terminal = second_terminal, 
+            ferries = ferries, passenger_fare = 8, car_fare = 18, truck_fare = 50
+        )
+
         daily_results = Sailings().daily_crossings(route, 'Tuesday', 7, 2016)
-        self.assertEqual(daily_results['total_passengers'], 8194)
-        self.assertEqual(daily_results['total_cars'], 1264)
-        self.assertEqual(daily_results['total_trucks'], 188)
-        self.assertEqual(daily_results['total_sailings'], 32)
+        self.assertEqual(daily_results['total_passengers'], 8270)
+        self.assertEqual(daily_results['total_cars'], 1276)
+        self.assertEqual(daily_results['total_trucks'], 190)
+        self.assertEqual(daily_results['total_sailings'], 35)
         self.assertEqual(daily_results['total_hours'], 20)
         
     def test_weekly_crossings(self):
-        route = {
-            'route_distance': 7.1,
-            'first_terminal': {
-                'id': 1,
-                'passenger_pool': 13000,
-                'car_pool': 2000,
-                'truck_pool': 300,
-            },
-            'second_terminal': {
-                'id': 2,
-                'passenger_pool': 13000,
-                'car_pool': 2000,
-                'truck_pool': 300,
-            },
-            'ferries': [
-                    {
-                        'speed': 18,
-                        'turnover_time': 0.2,
-                        'ferry_class': {
-                            'passengers': 2500,
-                            'cars': 200,
-                            'trucks': 60,
-                        }
-                        
-                    }
-                ]
-        }
+        ferry_class = Ferry_Class(
+            passengers = 2500, cars = 200, trucks = 60, burn_rate = 350, 
+            speed = 21, turnover_time = 0.2
+        )
+        ferry = Ferry(ferry_class = ferry_class)
+        ferries = [ferry]
+        first_terminal = Terminal(
+            id = 1, passenger_pool = 13000, car_pool = 2000, truck_pool = 300
+        )
+        second_terminal = Terminal(
+            id = 2, passenger_pool = 13000, car_pool = 2000, truck_pool = 300
+        )
+        route = Route(first_terminal = first_terminal, second_terminal = second_terminal, 
+            ferries = ferries, passenger_fare = 8, car_fare = 18, truck_fare = 50
+        )
+        
         weekly_results = Sailings().weekly_crossings(route, 7, 2016)
-        self.assertEqual(weekly_results['total_passengers'], 56218)
-        self.assertEqual(weekly_results['total_cars'], 8672)
-        self.assertEqual(weekly_results['total_trucks'], 1290)
-        self.assertEqual(weekly_results['total_sailings'], 245)
+        self.assertEqual(weekly_results['total_passengers'], 56750)
+        self.assertEqual(weekly_results['total_cars'], 8756)
+        self.assertEqual(weekly_results['total_trucks'], 1304)
+        self.assertEqual(weekly_results['total_sailings'], 269)
         self.assertEqual(weekly_results['total_hours'], 152)
     
     def test_calc_turn_results(self):
-        route = {
-            'route_distance': 7.1,
-            'first_terminal': {
-                'id': 1,
-                'passenger_pool': 13000,
-                'car_pool': 2000,
-                'truck_pool': 300,
-            },
-            'second_terminal': {
-                'id': 2,
-                'passenger_pool': 13000,
-                'car_pool': 2000,
-                'truck_pool': 300,
-            },
-            'passenger_fare': 8,
-            'car_fare': 18,
-            'truck_fare': 50,
-            'ferries': [
-                    {
-                        'speed': 18,
-                        'turnover_time': 0.2,
-                        'ferry_class': {
-                            'passengers': 2500,
-                            'cars': 200,
-                            'trucks': 60,
-                            'burn_rate': 350,
-                        }
-                        
-                    }
-                ]
-        }
+        ferry_class = Ferry_Class(
+            passengers = 2500, cars = 200, trucks = 60, burn_rate = 350, 
+            speed = 21, turnover_time = 0.2
+        )
+        ferry = Ferry(ferry_class = ferry_class)
+        ferries = [ferry]
+        first_terminal = Terminal(
+            id = 1, passenger_pool = 13000, car_pool = 2000, truck_pool = 300
+        )
+        second_terminal = Terminal(
+            id = 2, passenger_pool = 13000, car_pool = 2000, truck_pool = 300
+        )
+        route = Route(first_terminal = first_terminal, second_terminal = second_terminal, 
+            ferries = ferries, passenger_fare = 8, car_fare = 18, truck_fare = 50
+        )
+
         weekly_results = Financial_Calc().calc_weekly_results_for_route(route, 7, 2016)
-        self.assertEqual(weekly_results['passengers'], 56218)
-        self.assertEqual(weekly_results['cars'], 8672)
-        self.assertEqual(weekly_results['trucks'], 1290)
+        self.assertEqual(weekly_results['passengers'], 56750)
+        self.assertEqual(weekly_results['cars'], 8756)
+        self.assertEqual(weekly_results['trucks'], 1304)
         self.assertEqual(weekly_results['fuel_used'], 53200)
         self.assertAlmostEqual(weekly_results['fuel_cost'], 541147.80, 2)
-        self.assertAlmostEqual(weekly_results['passenger_revenue'], 449744, 2)
-        self.assertAlmostEqual(weekly_results['car_revenue'], 156096, 2)
-        self.assertAlmostEqual(weekly_results['truck_revenue'], 64500, 2)
+        self.assertAlmostEqual(weekly_results['passenger_revenue'], 454000, 2)
+        self.assertAlmostEqual(weekly_results['car_revenue'], 157608, 2)
+        self.assertAlmostEqual(weekly_results['truck_revenue'], 65200, 2)
         
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
update one missed tall_spaces to trucks property name change in data.json
add total_cars and total_trucks to Turn_Result model
fix error reporting in tests **init**
rewrite the models to use real class objects and not object subscription
rewrite the unit tests to match
changed test criteria slightly because new inputs altered calculations slightly
move turnover_time from the Ferry class to the Ferry_Class class (and clear the TODO)
add turnover_time to Ferry_Class test_game_endturn integration test (as well as fares)
delete dead route dictionaries from test_models_unit.py
