### PR TITLE
changing the structure of turn results

### DIFF
--- a/py_ferry/database.py
+++ b/py_ferry/database.py
@@ -72,6 +72,7 @@ class Ferry_Class(Base):
     turnover_time = Column(Integer)
     
     ferry = relationship('Ferry', backref = 'ferry_class')
+    ferry_result = relationship('Ferry_Result', backref = 'ferry_class')
 
 class Ferry(Base):
     __tablename__ = 'ferries'
@@ -168,15 +169,57 @@ class Route(Base):
     passenger_fare = Column(Float)
     car_fare = Column(Float)
     truck_fare = Column(Float)
+    
     first_terminal_id = Column(Integer, ForeignKey('terminals.id'))
     second_terminal_id = Column(Integer, ForeignKey('terminals.id'))
-    
     first_terminal = relationship('Terminal', uselist = False, foreign_keys = first_terminal_id)
     second_terminal = relationship('Terminal', uselist = False, foreign_keys = second_terminal_id)
     
     # base_route_id = Column(Integer, ForeignKey('base_routes.id'), nullable = False)
     game_id = Column(Integer, ForeignKey('games.id'), nullable = False)
     ferries = relationship('Ferry', backref = 'route')
+    
+class Ferry_Result(Base):
+    __tablename__ = 'ferry_results'
+    
+    def as_dictonary(self):
+        return {
+            "id": self.id
+        }
+    
+    id = Column(Integer, primary_key = True)
+    name = Column(String)
+    total_passengers = Column(Integer)
+    total_cars = Column(Integer)
+    total_trucks = Column(Integer)
+    fuel_used = Column(Float)
+    sailings = Column(Integer)
+    
+    ferry_class_id = Column(Integer, ForeignKey('ferry_classes.id'), nullable = False)
+    
+    route_result_id = Column(Integer, ForeignKey('route_results.id'))
+
+class Route_Result(Base):
+    __tablename__ = 'route_results'
+
+    def as_dictonary(self):
+        return {
+            "id": self.id
+        }
+        
+    id = Column(Integer, primary_key = True)
+    passenger_fare = Column(Float)
+    car_fare = Column(Float)
+    truck_fare = Column(Float)
+    
+    first_terminal_id = Column(Integer, ForeignKey('terminals.id'))
+    second_terminal_id = Column(Integer, ForeignKey('terminals.id'))
+    first_terminal = relationship('Terminal', uselist = False, foreign_keys = first_terminal_id)
+    second_terminal = relationship('Terminal', uselist = False, foreign_keys = second_terminal_id)
+    
+    ferry_results = relationship('Ferry_Result', backref = 'route_result')
+    
+    turn_result_id = Column(Integer, ForeignKey('turn_results.id'))
     
 class Turn_Result(Base):
     __tablename__ = 'turn_results'
@@ -190,12 +233,9 @@ class Turn_Result(Base):
         
     id = Column(Integer, primary_key = True)
     week_number = Column(Integer, nullable = False)
-    total_passengers = Column(Integer)
-    fuel_used = Column(Integer)
     fuel_cost = Column(Float)
-    passenger_revenue = Column(Float)
-    car_revenue = Column(Float)
-    truck_revenue = Column(Float)
     game_id = Column(Integer, ForeignKey('games.id'), nullable = False)
+    
+    route_results = relationship('Route_Result', backref = 'turn_result')
     
 Base.metadata.create_all(engine)

--- a/py_ferry/models.py
+++ b/py_ferry/models.py
@@ -163,10 +163,9 @@ class Schedule(object):
         }
         
     def route_interval(self, route):
-        print(route.ferries[0])
         return route.route_distance() / route.ferries[0].ferry_class.speed + route.ferries[0].ferry_class.turnover_time
         
-    # consider refactoring first_run and last_run into one loop through the shift
+    # TODO consider refactoring first_run and last_run into one loop through the shift
     def first_run(self, shift_mapping):
         for time in range(0, 24):
             if self.full_staffing[shift_mapping][time] == True:
@@ -287,23 +286,22 @@ class Financial_Calc(object):
         pass
     
     def calc_weekly_results_for_route(self, route, week, year):
-        sailings_results = Sailings().weekly_crossings(route, week, year)
-        fuel_used = route.ferries[0].ferry_class.burn_rate * sailings_results['total_hours']
-        fuel_cost = Fuel().cost_per_gallon() * fuel_used
-        passenger_revenue = sailings_results['total_passengers'] * route.passenger_fare
-        car_revenue = sailings_results['total_cars'] * route.car_fare
-        truck_revenue = sailings_results['total_trucks'] * route.truck_fare
-        
-        weekly_results = {
-            'passengers': sailings_results['total_passengers'],
-            'cars': sailings_results['total_cars'],
-            'trucks': sailings_results['total_trucks'],
-            'fuel_used': fuel_used,
-            'fuel_cost': fuel_cost,
-            'passenger_revenue': passenger_revenue,
-            'car_revenue': car_revenue,
-            'truck_revenue': truck_revenue,
-        }
+        weekly_results = []
+        ferry_result = {}
+        for ferry in route.ferries:
+            sailings_results = Sailings().weekly_crossings(route, week, year)
+            fuel_used = ferry.ferry_class.burn_rate * sailings_results['total_hours']
+            fuel_cost = Fuel().cost_per_gallon() * fuel_used
+            
+            ferry_results = {
+                'passengers': sailings_results['total_passengers'],
+                'cars': sailings_results['total_cars'],
+                'trucks': sailings_results['total_trucks'],
+                'fuel_used': fuel_used,
+                'name': ferry.name,
+                'ferry_class': ferry.ferry_class,
+            }
+            weekly_results.append(ferry_results)
         return weekly_results
     
     

--- a/tests/test_models_unit.py
+++ b/tests/test_models_unit.py
@@ -23,8 +23,9 @@ class Ferry_Class(object):
         self.turnover_time = turnover_time
 
 class Ferry(object):
-    def __init__(self, ferry_class):
+    def __init__(self, ferry_class, name):
         self.ferry_class = ferry_class
+        self.name = name
 
 class Route(object):
     def __init__(self, first_terminal, second_terminal, ferries, passenger_fare, car_fare, truck_fare):
@@ -57,7 +58,7 @@ class ModelTests(unittest.TestCase):
             passengers = 2500, cars = 200, trucks = 60, burn_rate = 350, 
             speed = 21, turnover_time = 0.2
         )
-        ferry = Ferry(ferry_class = ferry_class)
+        ferry = Ferry(ferry_class = ferry_class, name = 'M/V Wenatchee')
         ferries = [ferry]
         first_terminal = Terminal(
             id = 1, passenger_pool = 13000, car_pool = 2000, truck_pool = 300
@@ -78,7 +79,7 @@ class ModelTests(unittest.TestCase):
             passengers = 2500, cars = 200, trucks = 60, burn_rate = 350, 
             speed = 21, turnover_time = 0.2
         )
-        ferry = Ferry(ferry_class = ferry_class)
+        ferry = Ferry(ferry_class = ferry_class, name = 'M/V Wenatchee')
         ferries = [ferry]
         first_terminal = Terminal(
             id = 1, passenger_pool = 13000, car_pool = 2000, truck_pool = 300
@@ -102,7 +103,7 @@ class ModelTests(unittest.TestCase):
             passengers = 2500, cars = 200, trucks = 60, burn_rate = 350, 
             speed = 21, turnover_time = 0.2
         )
-        ferry = Ferry(ferry_class = ferry_class)
+        ferry = Ferry(ferry_class = ferry_class, name = 'M/V Wenatchee')
         ferries = [ferry]
         first_terminal = Terminal(
             id = 1, passenger_pool = 13000, car_pool = 2000, truck_pool = 300
@@ -126,7 +127,7 @@ class ModelTests(unittest.TestCase):
             passengers = 2500, cars = 200, trucks = 60, burn_rate = 350, 
             speed = 21, turnover_time = 0.2
         )
-        ferry = Ferry(ferry_class = ferry_class)
+        ferry = Ferry(ferry_class = ferry_class, name = 'M/V Wenatchee')
         ferries = [ferry]
         first_terminal = Terminal(
             id = 1, passenger_pool = 13000, car_pool = 2000, truck_pool = 300
@@ -139,14 +140,15 @@ class ModelTests(unittest.TestCase):
         )
 
         weekly_results = Financial_Calc().calc_weekly_results_for_route(route, 7, 2016)
-        self.assertEqual(weekly_results['passengers'], 56750)
-        self.assertEqual(weekly_results['cars'], 8756)
-        self.assertEqual(weekly_results['trucks'], 1304)
-        self.assertEqual(weekly_results['fuel_used'], 53200)
-        self.assertAlmostEqual(weekly_results['fuel_cost'], 541147.80, 2)
-        self.assertAlmostEqual(weekly_results['passenger_revenue'], 454000, 2)
-        self.assertAlmostEqual(weekly_results['car_revenue'], 157608, 2)
-        self.assertAlmostEqual(weekly_results['truck_revenue'], 65200, 2)
+        self.assertEqual(weekly_results[0]['passengers'], 56750)
+        self.assertEqual(weekly_results[0]['cars'], 8756)
+        self.assertEqual(weekly_results[0]['trucks'], 1304)
+        self.assertEqual(weekly_results[0]['fuel_used'], 53200)
+        self.assertEqual(weekly_results[0]['name'], 'M/V Wenatchee')
+        # self.assertAlmostEqual(weekly_results[0]['fuel_cost'], 541147.80, 2)
+        # self.assertAlmostEqual(weekly_results[0]['passenger_revenue'], 454000, 2)
+        # self.assertAlmostEqual(weekly_results[0]['car_revenue'], 157608, 2)
+        # self.assertAlmostEqual(weekly_results[0]['truck_revenue'], 65200, 2)
         
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
adding some efficiency and actually storing data that will be useful later
refactoring turn_results so that it contains route_results which in turn contains ferry_results
update the API to reflect the change in structure
update calc_weekly_results_for_route in the Financial_Calc class to return an array of ferry_results instead of an accumulation of results
