### PR TITLE
massive change in results data structures

### DIFF
--- a/notes/results mess.md
+++ b/notes/results mess.md
@@ -1,0 +1,18 @@
+by working backwards:
+
+Financial_Calc should return an array of "ferry informations", or metadata that is associated with a ferry that includes properties that relate to the turn results for each ferry
+
+[
+    {
+        ferry: ferry object
+        results: {
+            fuel_used: ...
+            total_passengers: ...
+        }
+    }
+]
+
+results are based on calculations performed for each day within the week
+so, Financial_Calc().calc_weekly_results_for_route() seems like an unnecessary indirection in hindsight
+
+sailings will need to take data for days and accumulate it with a ferry; passing these relatively complex arrays of objects between functions is a mess and is almost certiainly not necessary

--- a/py_ferry/api.py
+++ b/py_ferry/api.py
@@ -122,18 +122,17 @@ def games_endturn(game_id):
     routes_results = []
     # TODO there's got to be a better way to map an existing record to a new record
     for route in routes:
-        ferry_results = []
-        weekly_results = models.Financial_Calc().calc_weekly_results_for_route(
+        weekly_results = models.Sailings().weekly_crossings(
             route, game.current_week, game.current_year
         )
+        ferry_results = []
         for weekly_result in weekly_results:
             ferry_result = database.Ferry_Result(
-                fuel_used = weekly_result['fuel_used'],
-                total_passengers = weekly_result['passengers'],
-                total_cars = weekly_result['cars'],
-                total_trucks = weekly_result['trucks'],
-                ferry_class = weekly_result['ferry_class'],
-                name = weekly_result['name'],
+                fuel_used = weekly_result['results']['fuel_used'],
+                total_passengers = weekly_result['results']['total_passengers'],
+                total_cars = weekly_result['results']['total_cars'],
+                total_trucks = weekly_result['results']['total_trucks'],
+                ferry = weekly_result['ferry']
             )
             ferry_results.append(ferry_result)
             session.add(ferry_result)

--- a/py_ferry/database.py
+++ b/py_ferry/database.py
@@ -76,7 +76,6 @@ class Ferry_Class(Base, Public):
     turnover_time = Column(Integer)
     
     ferry = relationship('Ferry', backref = 'ferry_class')
-    ferry_result = relationship('Ferry_Result', backref = 'ferry_class')
 
 class Ferry(Base):
     __tablename__ = 'ferries'
@@ -99,6 +98,7 @@ class Ferry(Base):
     launched = Column(DateTime)
     game_id = Column(Integer, ForeignKey('games.id'), nullable = False)
     ferry_class_id = Column(Integer, ForeignKey('ferry_classes.id'), nullable = False)
+    ferry_result = relationship('Ferry_Result', backref = 'ferry')
     route_id = Column(Integer, ForeignKey('routes.id'))
     
 class Game(Base):
@@ -188,8 +188,7 @@ class Ferry_Result(Base):
     
     def as_dictionary(self):
         return {
-            "id": self.id,
-            "name": self.name,
+            "ferry": self.ferry.as_dictionary(),
             "total_passengers": self.total_passengers,
             "total_cars": self.total_cars,
             "total_trucks": self.total_trucks,
@@ -205,7 +204,7 @@ class Ferry_Result(Base):
     fuel_used = Column(Float)
     sailings = Column(Integer)
     
-    ferry_class_id = Column(Integer, ForeignKey('ferry_classes.id'), nullable = False)
+    ferry_id = Column(Integer, ForeignKey('ferries.id'), nullable = False)
     
     route_result_id = Column(Integer, ForeignKey('route_results.id'))
 

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -297,7 +297,10 @@ class TestAPI(unittest.TestCase):
             turnover_time = ferry_class_props['turnover_time'],
         )
         
-        ferry = database.Ferry(game = game, ferry_class = ferry_class_A, route = route)
+        ferry = database.Ferry(
+            game = game, ferry_class = ferry_class_A, route = route, 
+            name = 'M/V Wenatchee'
+        )
         
         session.add_all([game, seattle, bainbridge_island, route, ferry_class_A, ferry])
         session.commit()
@@ -337,6 +340,7 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(data['week'], 1)
         self.assertEqual(data['year'], 2000)
         self.assertEqual(data['route_results'][0]['id'], 1)
+        self.assertEqual(data['route_results'][0]['ferry_results'][0]['ferry']['name'], 'M/V Wenatchee')
         
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_models_unit.py
+++ b/tests/test_models_unit.py
@@ -39,7 +39,6 @@ class Route(object):
     def route_distance(self):
         return 7.1
     
-
 class ModelTests(unittest.TestCase):
     def test_fuel_cost(self):
         fuel_cost = Fuel().cost_per_gallon()
@@ -52,6 +51,26 @@ class ModelTests(unittest.TestCase):
     def test_passenger_demand(self):
         demand = Passenger().route_passenger_demand(30000, 7, 'Tuesday', 3, 2016)
         self.assertEqual(demand, 831)
+        
+    def test_route_interval(self):
+        ferry_class = Ferry_Class(
+            passengers = 2500, cars = 200, trucks = 60, burn_rate = 350, 
+            speed = 21, turnover_time = 0.2
+        )
+        ferry = Ferry(ferry_class = ferry_class, name = 'M/V Wenatchee')
+        ferries = [ferry]
+        first_terminal = Terminal(
+            id = 1, passenger_pool = 13000, car_pool = 2000, truck_pool = 300
+        )
+        second_terminal = Terminal(
+            id = 2, passenger_pool = 13000, car_pool = 2000, truck_pool = 300
+        )
+        route = Route(
+            first_terminal = first_terminal, second_terminal = second_terminal, 
+            ferries = ferries, passenger_fare = 8, car_fare = 18, truck_fare = 50
+        )
+        route_interval = Schedule().route_interval(route, ferry)
+        self.assertAlmostEqual(route_interval, 0.54, 2)
         
     def test_build_schedule(self):
         ferry_class = Ferry_Class(
@@ -71,7 +90,7 @@ class ModelTests(unittest.TestCase):
             ferries = ferries, passenger_fare = 8, car_fare = 18, truck_fare = 50
         )
         expected_schedule = [{'arrives': second_terminal, 'departs': first_terminal, 'time': 0}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 0.5380952380952381}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 5.3809523809523805}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 5.9190476190476184}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 6.457142857142856}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 6.995238095238094}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 7.533333333333332}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 8.071428571428571}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 8.60952380952381}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 9.147619047619047}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 9.685714285714285}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 10.223809523809523}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 10.761904761904761}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 11.299999999999999}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 11.838095238095237}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 12.376190476190475}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 12.914285714285713}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 13.45238095238095}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 13.990476190476189}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 14.528571428571427}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 15.066666666666665}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 15.604761904761903}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 16.142857142857142}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 16.68095238095238}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 17.21904761904762}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 17.757142857142856}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 18.295238095238094}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 18.833333333333332}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 19.37142857142857}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 19.909523809523808}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 20.447619047619046}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 20.985714285714284}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 21.523809523809522}, {'arrives': first_terminal, 'departs': second_terminal, 'time': 22.06190476190476}, {'arrives': second_terminal, 'departs': first_terminal, 'time': 22.599999999999998}]
-        schedule = Schedule().build_schedule(route, 'Monday')
+        schedule = Schedule().build_schedule(route, ferry, 'Monday')
         self.assertEqual(schedule, expected_schedule)
 
     def test_daily_crossings(self):
@@ -92,11 +111,11 @@ class ModelTests(unittest.TestCase):
         )
 
         daily_results = Sailings().daily_crossings(route, 'Tuesday', 7, 2016)
-        self.assertEqual(daily_results['total_passengers'], 8270)
-        self.assertEqual(daily_results['total_cars'], 1276)
-        self.assertEqual(daily_results['total_trucks'], 190)
-        self.assertEqual(daily_results['total_sailings'], 35)
-        self.assertEqual(daily_results['total_hours'], 20)
+        self.assertEqual(daily_results[0]['results']['total_passengers'], 8270)
+        self.assertEqual(daily_results[0]['results']['total_cars'], 1276)
+        self.assertEqual(daily_results[0]['results']['total_trucks'], 190)
+        # self.assertEqual(daily_results[0]['results']['total_sailings'], 35)
+        # self.assertEqual(daily_results[0]['results']['total_hours'], 20)
         
     def test_weekly_crossings(self):
         ferry_class = Ferry_Class(
@@ -116,19 +135,26 @@ class ModelTests(unittest.TestCase):
         )
         
         weekly_results = Sailings().weekly_crossings(route, 7, 2016)
-        self.assertEqual(weekly_results['total_passengers'], 56750)
-        self.assertEqual(weekly_results['total_cars'], 8756)
-        self.assertEqual(weekly_results['total_trucks'], 1304)
-        self.assertEqual(weekly_results['total_sailings'], 269)
-        self.assertEqual(weekly_results['total_hours'], 152)
-    
-    def test_calc_turn_results(self):
-        ferry_class = Ferry_Class(
+        self.assertEqual(weekly_results[0]['ferry'], ferry)
+        self.assertEqual(weekly_results[0]['results']['total_passengers'], 56750)
+        self.assertEqual(weekly_results[0]['results']['total_cars'], 8756)
+        self.assertEqual(weekly_results[0]['results']['total_trucks'], 1304)
+        self.assertEqual(weekly_results[0]['results']['total_sailings'], 269)
+        self.assertEqual(weekly_results[0]['results']['total_hours'], 152)
+        
+    def test_calc_turn_results_with_two_ferries(self):
+        # ferryA will carry passengers, cars, and trucks and ferryB only passengers
+        ferry_classA = Ferry_Class(
             passengers = 2500, cars = 200, trucks = 60, burn_rate = 350, 
             speed = 21, turnover_time = 0.2
         )
-        ferry = Ferry(ferry_class = ferry_class, name = 'M/V Wenatchee')
-        ferries = [ferry]
+        ferry_classB = Ferry_Class(
+            passengers = 250, cars = 0, trucks = 0, burn_rate = 35, 
+            speed = 30, turnover_time = 0.1
+        )
+        ferryA = Ferry(ferry_class = ferry_classA, name = 'M/V Wenatchee')
+        ferryB = Ferry(ferry_class = ferry_classB, name = 'M/V Puyallup')
+        ferries = [ferryA, ferryB]
         first_terminal = Terminal(
             id = 1, passenger_pool = 13000, car_pool = 2000, truck_pool = 300
         )
@@ -139,16 +165,21 @@ class ModelTests(unittest.TestCase):
             ferries = ferries, passenger_fare = 8, car_fare = 18, truck_fare = 50
         )
 
-        weekly_results = Financial_Calc().calc_weekly_results_for_route(route, 7, 2016)
-        self.assertEqual(weekly_results[0]['passengers'], 56750)
-        self.assertEqual(weekly_results[0]['cars'], 8756)
-        self.assertEqual(weekly_results[0]['trucks'], 1304)
-        self.assertEqual(weekly_results[0]['fuel_used'], 53200)
-        self.assertEqual(weekly_results[0]['name'], 'M/V Wenatchee')
-        # self.assertAlmostEqual(weekly_results[0]['fuel_cost'], 541147.80, 2)
-        # self.assertAlmostEqual(weekly_results[0]['passenger_revenue'], 454000, 2)
-        # self.assertAlmostEqual(weekly_results[0]['car_revenue'], 157608, 2)
-        # self.assertAlmostEqual(weekly_results[0]['truck_revenue'], 65200, 2)
+        weekly_results = Sailings().weekly_crossings(route, 7, 2016)
+        self.assertEqual(weekly_results[0]['ferry'], ferryA)
+        self.assertEqual(weekly_results[1]['ferry'], ferryB)
+        self.assertEqual(weekly_results[0]['results']['total_passengers'], 52368)
+        self.assertEqual(weekly_results[1]['results']['total_passengers'], 4382)
+        self.assertEqual(weekly_results[0]['results']['total_cars'], 8756)
+        self.assertEqual(weekly_results[1]['results']['total_cars'], 0)
+        self.assertEqual(weekly_results[0]['results']['total_trucks'], 1304)
+        self.assertEqual(weekly_results[1]['results']['total_trucks'], 0)
+        self.assertEqual(weekly_results[0]['results']['total_sailings'], 269)
+        self.assertEqual(weekly_results[1]['results']['total_sailings'], 435)
+        self.assertEqual(weekly_results[0]['results']['fuel_used'], 53200)
+        self.assertEqual(weekly_results[1]['results']['fuel_used'], 5320)
+        self.assertEqual(weekly_results[0]['ferry'].name, 'M/V Wenatchee')
+        self.assertEqual(weekly_results[1]['ferry'].name, 'M/V Puyallup')
         
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
test results chain - get a ferry name from the array of ferries, which comes from the array of routes, which belongs to a turn_results record
clean dead code out of test_models_unit.py
add unit test for route_interval
delete now unnecessary class Financial_Calc
refactor unit tests to match new scheme
relate Ferry_Result with Ferry instead of Ferry_Class with added name property
