### PR TITLE
route creation and end turn prototype

### DIFF
--- a/client/models/games.js
+++ b/client/models/games.js
@@ -59,6 +59,21 @@ angular.module('py-ferry')
         return Error;
     });
   };
+  
+  Game.endTurn = function(gameId) {
+    var d = $q.defer();
+    $http({
+      method: 'GET',
+      url: apiUrl + '/games/' + gameId + '/endturn'
+    })
+    .then(function(response) {
+        d.resolve(response.data);
+    })
+    .catch(function(error) {
+        d.reject(error);
+    });
+    return d.promise;
+  };
 
   return Game;
 }]);

--- a/client/views/games/games-detail-ferry-buy-modal.js
+++ b/client/views/games/games-detail-ferry-buy-modal.js
@@ -18,7 +18,7 @@ angular.module('py-ferry')
   $scope.buy = function () {
     Ferry.buy(game.id, $scope.ferry)
     .then(function(response) {
-      $uibModalInstance.close();
+      $uibModalInstance.close(response.data);
     })
     .catch(function(error) {
       console.error(error);

--- a/client/views/games/games-detail-route-create-modal.jade
+++ b/client/views/games/games-detail-route-create-modal.jade
@@ -13,9 +13,12 @@
                 .form-group
                     select(ng-model="route.terminal2Id")
                         option(value="{{terminal.id}}" ng-repeat="terminal in terminals" ng-bind="terminal.name")
-        // .form-group(style="clear: both; padding-top: 50px;")
-        //     label(for="name") Name
-        //     input(type="text" id="name" ng-model="ferry.name" placeholder="Name")
+        .row
+            .col-xs-12
+                .form-group
+                    div(ng-repeat="ferry in ferries")
+                        label(ng-bind="ferry.name")
+                        input.checkbox(type="checkbox" ng-model="route.ferries[ferry.id]")
     .modal-footer
         button.btn.btn-default(ng-click="create()") Create
         button.btn.btn-default(ng-click="cancel()") Cancel

--- a/client/views/games/games-detail-route-create-modal.js
+++ b/client/views/games/games-detail-route-create-modal.js
@@ -1,14 +1,21 @@
 'use strict';
 
 angular.module('py-ferry')
-.controller('GamesDetailRouteCreateModalInstanceCtrl', ['$scope', '$uibModalInstance', 'terminals', 'game', 'Route', function ($scope, $uibModalInstance, terminals, game, Route) {
+.controller('GamesDetailRouteCreateModalInstanceCtrl', ['$scope', '$uibModalInstance', 'terminals', 'game', 'ferries', 'Route', function ($scope, $uibModalInstance, terminals, game, ferries, Route) {
 
   $scope.terminals = terminals;
   $scope.game = game;
+  $scope.ferries = ferries;
   
   $scope.route = {};
   
   $scope.create = function () {
+    var ferriesObject = $scope.route.ferries;
+    $scope.route.ferries = [];
+    for(var ferry in ferriesObject) {
+      $scope.route.ferries.push(ferry);
+    }
+    console.log($scope.route);
     Route.create(game.id, $scope.route)
     .then(function(response) {
       $uibModalInstance.close();

--- a/client/views/games/games-detail.jade
+++ b/client/views/games/games-detail.jade
@@ -31,4 +31,6 @@
                         div.panel-default(uib-accordion-group ng-repeat="route in routes")
                             div(uib-accordion-heading) test
                             p {{route.first_terminal.name}} – {{route.second_terminal.name}}
+            .row
+                button.btn.btn-warning(ng-click="endTurn()") End Turn
         

--- a/client/views/games/games-detail.js
+++ b/client/views/games/games-detail.js
@@ -56,6 +56,10 @@ function($scope, $state, Game, Utils, $uibModal, FerryClass, Terminal, Ferry, Ro
     
     $scope.animationsEnabled = true;
     
+    $scope.endTurn = function() {
+        Game.endTurn(gameId);  
+    };
+    
     $scope.ferry = {};
     
     $scope.ferry.buy = function() {
@@ -98,6 +102,10 @@ function($scope, $state, Game, Utils, $uibModal, FerryClass, Terminal, Ferry, Ro
                game: function() {
                    console.log($scope.game);
                    return $scope.game;
+               },
+               ferries: function() {
+                   console.log($scope.game);
+                   return $scope.ferries;
                }
            }
         });

--- a/client/views/games/games-detail.js
+++ b/client/views/games/games-detail.js
@@ -80,7 +80,8 @@ function($scope, $state, Game, Utils, $uibModal, FerryClass, Terminal, Ferry, Ro
            }
         });
         
-        modalInstance.result.then(function() {
+        modalInstance.result.then(function(ferry) {
+            $scope.ferries.push(ferry);
         }, function() {
           console.info('Modal dismissed at: ' + new Date());
         });

--- a/data.json
+++ b/data.json
@@ -8,6 +8,7 @@
                 "cars": 202,
                 "trucks": 60,
                 "speed": 18,
+                "turnover_time": 12,
                 "burn_rate": 350,
                 "cost": 80000000,
                 "residual_value": 2000000
@@ -18,6 +19,7 @@
                 "cars": 188,
                 "trucks": 60,
                 "speed": 18,
+                "turnover_time": 12,
                 "burn_rate": 350,
                 "cost": 80000000,
                 "residual_value": 2000000
@@ -28,6 +30,7 @@
                 "cars": 144,
                 "trucks": 30,
                 "speed": 20,
+                "turnover_time": 12,
                 "burn_rate": 350,
                 "cost": 80000000,
                 "residual_value": 2000000
@@ -38,6 +41,7 @@
                 "cars": 144,
                 "trucks": 34,
                 "speed": 17,
+                "turnover_time": 11,
                 "burn_rate": 350,
                 "cost": 80000000,
                 "residual_value": 2000000
@@ -48,6 +52,7 @@
                 "cars": 124,
                 "trucks": 26,
                 "speed": 16,
+                "turnover_time": 10,
                 "burn_rate": 350,
                 "cost": 80000000,
                 "residual_value": 2000000
@@ -58,6 +63,7 @@
                 "cars": 87,
                 "trucks": 30,
                 "speed": 13,
+                "turnover_time": 8,
                 "burn_rate": 350,
                 "cost": 80000000,
                 "residual_value": 2000000
@@ -68,6 +74,7 @@
                 "cars": 64,
                 "trucks": 9,
                 "speed": 15,
+                "turnover_time": 8,
                 "burn_rate": 350,
                 "cost": 80000000,
                 "residual_value": 2000000
@@ -78,6 +85,7 @@
                 "cars": 34,
                 "trucks": 12,
                 "speed": 10,
+                "turnover_time": 6,
                 "burn_rate": 350,
                 "cost": 750000,
                 "residual_value": 100000

--- a/data.json
+++ b/data.json
@@ -91,19 +91,25 @@
                 "name": "Seattle",
                 "lat": 47.6025001,
                 "lon": -122.33857590000002,
-                "passenger_pool": 13000
+                "passenger_pool": 13000,
+                "car_pool": 2000,
+                "truck_pool": 300
             },
             {
                 "name": "Bainbridge Island",
                 "lat": 47.623089,
                 "lon": -122.511171,
-                "passenger_pool": 13000
+                "passenger_pool": 13000,
+                "car_pool": 2000,
+                "truck_pool": 300
             },
             {
                 "name": "Bremerton",
                 "lat": 47.561987,
                 "lon": -122.6273237,
-                "passenger_pool": 13000
+                "passenger_pool": 13000,
+                "car_pool": 2000,
+                "truck_pool": 300
             }
         ]
     }

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+dropdb py-ferry
+createdb py-ferry
+python manage.py importdata
+python manage.py adduser
+python manage.py run

--- a/py_ferry/api.py
+++ b/py_ferry/api.py
@@ -239,6 +239,11 @@ def routes_create(game_id):
     first_terminal = session.query(database.Terminal).get(json_data['terminal1Id'])
     second_terminal = session.query(database.Terminal).get(json_data['terminal2Id'])
     
+    ferries = []
+    for ferry in json_data['ferries']:
+        ferry = session.query(database.Ferry).get(ferry)
+        ferries.append(ferry)
+    
     route = database.Route(first_terminal = first_terminal, second_terminal = second_terminal, game = game)
     
     session.add(route)

--- a/py_ferry/api.py
+++ b/py_ferry/api.py
@@ -244,7 +244,7 @@ def routes_create(game_id):
         ferry = session.query(database.Ferry).get(ferry)
         ferries.append(ferry)
     
-    route = database.Route(first_terminal = first_terminal, second_terminal = second_terminal, game = game)
+    route = database.Route(first_terminal = first_terminal, second_terminal = second_terminal, game = game, ferries = ferries)
     
     session.add(route)
     session.commit()
@@ -268,12 +268,20 @@ def games_endturn(game_id):
     
     routes_results = []
     # TODO there's got to be a better way to map an existing record to a new record
+    
+    total_fuel = 0
+    total_revenue = 0
+    
     for route in routes:
         weekly_results = models.Sailings().weekly_crossings(
             route, game.current_week, game.current_year
         )
         ferry_results = []
         for weekly_result in weekly_results:
+            total_fuel += weekly_result['results']['fuel_used']
+            total_revenue += weekly_result['results']['total_passengers'] * route.passenger_fare
+            total_revenue += weekly_result['results']['total_cars'] * route.car_fare
+            total_revenue += weekly_result['results']['total_trucks'] * route.truck_fare
             ferry_result = database.Ferry_Result(
                 fuel_used = weekly_result['results']['fuel_used'],
                 total_passengers = weekly_result['results']['total_passengers'],
@@ -304,6 +312,9 @@ def games_endturn(game_id):
     session.add(turn_result)
     
     game.current_week += 1
+    print(total_fuel)
+    print(total_revenue)
+    game.cash_available += total_revenue - total_fuel * models.Fuel().cost_per_gallon()
     
     session.commit()
 

--- a/py_ferry/database.py
+++ b/py_ferry/database.py
@@ -177,9 +177,9 @@ class Route(Base):
         return vincenty(place_A, place_B).nm * ROUTE_ARC_MULTIPLER # in nautical miles
     
     id = Column(Integer, primary_key = True)
-    passenger_fare = Column(Float)
-    car_fare = Column(Float)
-    truck_fare = Column(Float)
+    passenger_fare = Column(Float, default = 0)
+    car_fare = Column(Float, default = 0)
+    truck_fare = Column(Float, default = 0)
     
     first_terminal_id = Column(Integer, ForeignKey('terminals.id'))
     second_terminal_id = Column(Integer, ForeignKey('terminals.id'))

--- a/py_ferry/models.py
+++ b/py_ferry/models.py
@@ -88,6 +88,7 @@ class Passenger(object):
         self.growth_rate = 1.025
 
     def route_passenger_demand(self, passengers, hour, day, week, year):
+        print(passengers)
         week_floor = math.floor(week / 4) * 4 + 1
         base_demand = self.day_demand[day][hour] * self.week_demand[week_floor]
         offset_years = year - self.base_year

--- a/py_ferry/models.py
+++ b/py_ferry/models.py
@@ -88,7 +88,6 @@ class Passenger(object):
         self.growth_rate = 1.025
 
     def route_passenger_demand(self, passengers, hour, day, week, year):
-        print(passengers)
         week_floor = math.floor(week / 4) * 4 + 1
         base_demand = self.day_demand[day][hour] * self.week_demand[week_floor]
         offset_years = year - self.base_year

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -627,14 +627,45 @@ class TestAPI(unittest.TestCase):
         pw = 'notsecret'
         bob = database.User(name = 'ferrycapn', email = 'capnonthebridge@gmail.com', password = generate_password_hash(pw))
         
+        ferry_class_props = { 
+            'name': 'Jumbo Mark II',
+            'passengers': 2500,
+            'cars': 202,
+            'trucks': 60,
+            'speed': 21,
+            'burn_rate': 350,
+            'turnover_time': 0.2,
+            'cost': 50000000
+        }
+        
+        ferry_class_A = database.Ferry_Class(
+            name = ferry_class_props['name'],
+            passengers = ferry_class_props['passengers'],
+            cars = ferry_class_props['cars'],
+            trucks = ferry_class_props['trucks'],
+            speed = ferry_class_props['speed'],
+            burn_rate = ferry_class_props['burn_rate'],
+            turnover_time = ferry_class_props['turnover_time'],
+            cost = ferry_class_props['cost'],
+        )
+        
         game = database.Game(player = bob)
         
-        session.add_all([seattle, bainbridge_island, bob, game])
+        ferry = database.Ferry(
+            ferry_class = ferry_class_A,
+            game = game,
+            name = 'M/V Minnow'
+        )
+        
+        session.add_all([seattle, bainbridge_island, bob, game, ferry_class_A, ferry])
         session.commit()
         
         data = {
             "terminal1Id": seattle.id,
-            "terminal2Id": bainbridge_island.id
+            "terminal2Id": bainbridge_island.id,
+            "ferries": [
+                ferry.id
+            ]
         }
         
         token = self.get_jwt(bob.name, pw)


### PR DESCRIPTION
gen: add car_pool and truck_pool numbers to terminals in data.json
FE: add quick and dirty wiring for endturn route so that we can test that from the front-end, including a button
FE: add checkboxes for ferries so that ferries can be selected when creating routes, and the code that supports the display of ferries
FE: write code that translates an array of objects where there is an ID for a ferry to an array of IDs
gen: update test for route creation to include creating a test ferry (and class) in the db and passing the ID in an array called ferries (to match the change noted above)
