### PR TITLE
some maintenance and game experience improvements

### DIFF
--- a/client/models/ferries.js
+++ b/client/models/ferries.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('py-ferry')
-.factory('Ferry', ['$http', '$window', '$q', 'apiUrl', '_', function($http, $window, $q, apiUrl, _) {
+.factory('Ferry', ['$http', '$window', '$q', 'apiUrl', '_', '$rootScope', function($http, $window, $q, apiUrl, _, $rootScope) {
   function Ferry() {}
   
   Ferry.buy = function(gameId, data) {
@@ -13,7 +13,8 @@ angular.module('py-ferry')
       data: data
     })
     .then(function(response) {
-        d.resolve(response);
+        $rootScope.$emit('updateGame', gameId);
+        d.resolve(response.data);
     })
     .catch(function(error) {
         d.reject(error);

--- a/client/models/routes.js
+++ b/client/models/routes.js
@@ -5,18 +5,26 @@ angular.module('py-ferry')
   function Route() {}
   
     Route.create = function(gameId, data) {
-        return $http({
+        var d = $q.defer();
+        $http({
           method: 'POST',
           url: apiUrl + '/games/' + gameId + '/routes',
           data: data
+        })
+        .then(function(response) {
+            d.resolve(response.data);
+        })
+        .catch(function(error) {
+            d.reject(error);
         });
+        return d.promise;
     };
   
     Route.list = function(gameId) {
         var d = $q.defer();
         $http({
-        method: 'GET',
-        url: apiUrl + '/games/' + gameId + '/routes'
+          method: 'GET',
+          url: apiUrl + '/games/' + gameId + '/routes'
         })
         .then(function(response) {
             d.resolve(response.data);

--- a/client/views/games/games-detail-ferry-buy-modal.js
+++ b/client/views/games/games-detail-ferry-buy-modal.js
@@ -18,7 +18,7 @@ angular.module('py-ferry')
   $scope.buy = function () {
     Ferry.buy(game.id, $scope.ferry)
     .then(function(response) {
-      $uibModalInstance.close(response.data);
+      $uibModalInstance.close(response);
     })
     .catch(function(error) {
       console.error(error);

--- a/client/views/games/games-detail-route-create-modal.jade
+++ b/client/views/games/games-detail-route-create-modal.jade
@@ -19,6 +19,20 @@
                     div(ng-repeat="ferry in ferries")
                         label(ng-bind="ferry.name")
                         input.checkbox(type="checkbox" ng-model="route.ferries[ferry.id]")
+        .row
+            .col-xs-4
+                .form-group
+                    label(for="passenger") Passenger Fare
+                    input(type="currency" id="passenger" ng-model="route.passenger_fare") 
+            .col-xs-4
+                .form-group
+                    label(for="car") Car Fare
+                    input(type="currency" id="car" ng-model="route.car_fare")
+            .col-xs-4
+                .form-group
+                    label(for="truck") Truck Fare
+                    input(type="currency" id="truck" ng-model="route.truck_fare")
+                
     .modal-footer
         button.btn.btn-default(ng-click="create()") Create
         button.btn.btn-default(ng-click="cancel()") Cancel

--- a/client/views/games/games-detail.js
+++ b/client/views/games/games-detail.js
@@ -34,8 +34,11 @@ function($scope, $state, Game, Utils, $uibModal, FerryClass, Terminal, Ferry, Ro
            
         Game.fetch(gameId)
             .then(function(response) {
-                $scope.game = response.data;
-                console.log($scope.game);
+                $scope.game = Game.activeGame;
+                $scope.game = function() {
+                    return Game.getActiveGame();
+                  };
+                console.log($scope.game());
             })
             .catch(function(error){
                 console.error(error);
@@ -75,7 +78,7 @@ function($scope, $state, Game, Utils, $uibModal, FerryClass, Terminal, Ferry, Ro
                },
                game: function() {
                    console.log($scope.game);
-                   return $scope.game;
+                   return $scope.game();
                }
            }
         });
@@ -102,7 +105,7 @@ function($scope, $state, Game, Utils, $uibModal, FerryClass, Terminal, Ferry, Ro
                },
                game: function() {
                    console.log($scope.game);
-                   return $scope.game;
+                   return $scope.game();
                },
                ferries: function() {
                    console.log($scope.game);
@@ -111,9 +114,16 @@ function($scope, $state, Game, Utils, $uibModal, FerryClass, Terminal, Ferry, Ro
            }
         });
         
-        modalInstance.result.then(function() {
+        modalInstance.result.then(function(route) {
+            $scope.routes.push(route);
         }, function() {
           console.info('Modal dismissed at: ' + new Date());
         });
     }
+    
+    $scope.$on('$locationChangeStart', function( event, newUrl ) {
+      if (newUrl.indexOf('/games/') == -1) {
+        Game.activeGame = {};
+      }
+    });
 }]);

--- a/client/views/header/header.jade
+++ b/client/views/header/header.jade
@@ -11,6 +11,11 @@ nav#header.navbar.navbar-default.navbar-fixed-top(ng-controller="NavCtrl")
         span.icon-bar
       a.navbar-brand(ui-sref='home' href="") py-ferry
     .collapse.navbar-collapse(uib-collapse="isCollapsed" collapse="isCollapsed")
+      div(ng-if="game().current_year")
+        span Year: {{game().current_year}}
+        span Week: {{game().current_week}}
+        span Cash: {{game().cash_available | currency : '$' : 0}}
+      
       // ul.main-menu.nav.navbar-nav.navbar-left
       //   li.dropdown
       //     a(href="" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false") Games

--- a/client/views/header/header.js
+++ b/client/views/header/header.js
@@ -1,14 +1,16 @@
 'use strict';
 
 angular.module('py-ferry')
-.controller('NavCtrl', ['$scope', '$state', 'User', 'Utils', function($scope, $state, User, Utils) {
-  
-  // Utils.userLoggedIn();
+.controller('NavCtrl', ['$scope', '$state', 'User', 'Utils', 'Game', function($scope, $state, User, Utils, Game) {
   
   $scope.logout = function() {
     User.logout();
     $state.go('login');
   }
+ 
+  $scope.game = function() {
+    return Game.getActiveGame();
+  };
   
   $scope.isCollapsed = true;
 

--- a/data.json
+++ b/data.json
@@ -86,7 +86,7 @@
                 "trucks": 12,
                 "speed": 10,
                 "turnover_time": 6,
-                "burn_rate": 350,
+                "burn_rate": 18,
                 "cost": 750000,
                 "residual_value": 100000
             }

--- a/py_ferry/database.py
+++ b/py_ferry/database.py
@@ -90,6 +90,7 @@ class Ferry(Base):
             "name": self.name,
             "ferry_class": self.ferry_class.as_dictionary(),
             "launched": self.launched,
+            "active": self.active,
         }
     
     def depreciated_value(self, year):
@@ -99,6 +100,7 @@ class Ferry(Base):
         return self.ferry_class.residual_value - self.ferry_class.cost * age / self.ferry_class.usable_life
         
     id = Column(Integer, primary_key = True)
+    active = Column(Boolean, default = True)
     name = Column(String(64))
     launched = Column(DateTime)
     game_id = Column(Integer, ForeignKey('games.id'), nullable = False)

--- a/py_ferry/models.py
+++ b/py_ferry/models.py
@@ -210,18 +210,19 @@ class Sailings(object):
     def daily_crossings(self, route, day, week, year):
         accumulations = []
         for ferry in route.ferries:
-            schedule = Schedule().build_schedule(route, ferry, day)
-            accumulations.append({
-                'ferry': ferry,
-                'schedule': schedule,
-                'results': {
-                    'total_passengers': 0,
-                    'total_cars': 0,
-                    'total_trucks': 0,
-                    'total_sailings': len(schedule),
-                    'total_hours': Schedule().hours_of_operations(day),
-                    }
-                })
+            if ferry.active == True:
+                schedule = Schedule().build_schedule(route, ferry, day)
+                accumulations.append({
+                    'ferry': ferry,
+                    'schedule': schedule,
+                    'results': {
+                        'total_passengers': 0,
+                        'total_cars': 0,
+                        'total_trucks': 0,
+                        'total_sailings': len(schedule),
+                        'total_hours': Schedule().hours_of_operations(day),
+                        }
+                    })
         # TODO all these declarations and the repition of the queue code smells
         first_terminal_queue = {
             'passengers': 0,
@@ -270,17 +271,18 @@ class Sailings(object):
     def weekly_crossings(self, route, week, year):
         accumulations = []
         for ferry in route.ferries:
-            accumulations.append({
-                'ferry': ferry,
-                'results': {
-                    'total_passengers': 0,
-                    'total_cars': 0,
-                    'total_trucks': 0,
-                    'total_sailings': 0,
-                    'total_hours': 0,
-                    'fuel_used': 0,
-                    }
-                })
+            if ferry.active == True:
+                accumulations.append({
+                    'ferry': ferry,
+                    'results': {
+                        'total_passengers': 0,
+                        'total_cars': 0,
+                        'total_trucks': 0,
+                        'total_sailings': 0,
+                        'total_hours': 0,
+                        'fuel_used': 0,
+                        }
+                    })
         days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
         
         for day in days:

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -531,7 +531,7 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(response.mimetype, 'application/json')
         
         data = json.loads(response.data.decode('ascii'))
-        self.assertEqual(len(data), 4)
+        self.assertEqual(len(data), 5)
         
     def test_ferry_post_insufficient_funds(self):
         ''' test the purchasing of a ferry when player doesn't have enough available cash '''
@@ -663,6 +663,9 @@ class TestAPI(unittest.TestCase):
         data = {
             "terminal1Id": seattle.id,
             "terminal2Id": bainbridge_island.id,
+            "passenger_fare": 8.50,
+            "car_fare": 18,
+            "truck_fare": 48,
             "ferries": [
                 ferry.id
             ]
@@ -783,7 +786,11 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(response.mimetype, 'application/json')
         
         data = json.loads(response.data.decode('ascii'))
-        self.assertEqual(data['message'], 'success')
+        self.assertEqual(len(data), 8)
+        
+        data = json.loads(response.data.decode('ascii'))
+        self.assertEqual(data['current_week'], 2)
+        self.assertEqual(data['current_year'], 2000)
 
         response = self.client.get('/api/games/' + str(game.id),
             headers = [

--- a/tests/test_models_unit.py
+++ b/tests/test_models_unit.py
@@ -26,6 +26,7 @@ class Ferry(object):
     def __init__(self, ferry_class, name):
         self.ferry_class = ferry_class
         self.name = name
+        self.active = True
 
 class Route(object):
     def __init__(self, first_terminal, second_terminal, ferries, passenger_fare, car_fare, truck_fare):


### PR DESCRIPTION
FE: add emit event when buying a ferry so to update game
FE: listen to emit event to update activeGame
FE: refactor Game.fetch to store the retrieved game in a class variable
FE: add Game.getActiveGame to return the active game when requested by controllers
BE: add functionality to games_endturn to not just increment the current_week, but check if it is the last week of the year and handle accordingly
BE: refactor games_endturn to return a new game object instead of a success message
FE: refactor Game.endTurn to handle the return of a game object instead of success message
FE: refactor Route.create to return a custom promise instead of $http (the only benefit being we are returning the payload itself and not the entire response)
BE: update routes_create endpoint to add fare properties to the new record
BE: wrap session.add and session.commit in try:expect in case we receive bad data from the front-end (this is a hack for now) and return error
FE: added game stats to header
FE: wrap $scope.game in a function that gets returned from the method in the model
FE: update route modalInstance to handle the returned route and update the array
gen: fix the burn rate for the Hiyu according to my research
BE: add active property to Ferry class so that ferries can be sold and then made inactive
BE: wrap calculation blocks in a conditional block to check if the ferry is active or not
BE: updated tests to accomodate the new active property
BE: updated tests to handle fares when returned with a route object
