### PR TITLE
making progress with turn results

### DIFF
--- a/client/models/turnResults.js
+++ b/client/models/turnResults.js
@@ -1,0 +1,23 @@
+'use strict';
+
+angular.module('py-ferry')
+.factory('TurnResult', ['$http', '$window', '$q', 'apiUrl', '_', function($http, $window, $q, apiUrl, _) {
+  function TurnResult() {}
+
+  TurnResult.fetch = function(gameId, yearNumber, weekNumber) {
+    var d = $q.defer();
+    $http({
+      method: 'GET',
+      url: apiUrl + '/games/' + gameId + '/turn_results/' + yearNumber + '/week/' + weekNumber
+    })
+    .then(function(response) {
+        d.resolve(response.data);
+    })
+    .catch(function(error) {
+        d.reject(error);
+    });
+    return d.promise;
+  };
+
+  return TurnResult;
+}]);

--- a/client/views/games/games-detail.jade
+++ b/client/views/games/games-detail.jade
@@ -33,4 +33,5 @@
                             p {{route.first_terminal.name}} – {{route.second_terminal.name}}
             .row
                 button.btn.btn-warning(ng-click="endTurn()") End Turn
+                button.btn.btn-warning(ng-click="turnResults.open()") View Last Turn's Results
         

--- a/client/views/games/games-detail.js
+++ b/client/views/games/games-detail.js
@@ -2,8 +2,8 @@
 
 angular.module('py-ferry')
 .controller('GamesDetailCtrl', 
-['$scope', '$state', 'Game', 'Utils', '$uibModal', 'FerryClass', 'Terminal', 'Ferry', 'Route', '_',
-function($scope, $state, Game, Utils, $uibModal, FerryClass, Terminal, Ferry, Route, _) {
+['$scope', '$state', 'Game', 'Utils', '$uibModal', 'FerryClass', 'Terminal', 'Ferry', 'Route', 'TurnResult', '_',
+function($scope, $state, Game, Utils, $uibModal, FerryClass, Terminal, Ferry, Route, TurnResult, _) {
     
     $scope.oneAtATime = true;
     
@@ -182,6 +182,35 @@ function($scope, $state, Game, Utils, $uibModal, FerryClass, Terminal, Ferry, Ro
             var index = _.findIndex($scope.routes, {id: route.id});
             console.log(index);
             $scope.routes.splice(index, 1, route);
+        }, function() {
+          console.info('Modal dismissed at: ' + new Date());
+        });
+    }
+    
+    $scope.turnResults = {};
+    
+    $scope.turnResults.open = function() {
+        var modalInstance = $uibModal.open({
+           animation: $scope.animationsEnabled,
+           templateUrl: 'views/games/modals/games-detail-turn-results-modal.html',
+           controller: 'GamesDetailTurnResultsModalInstanceCtrl',
+           size: 'lg',
+           resolve: {
+              turnResult: function() {
+                  // TODO handle the new year problem here
+                  return TurnResult.fetch($scope.game().id, $scope.game().current_year, $scope.game().current_week - 1)
+                  .then(function(response) {
+                      return response;
+                  })
+                  .catch(function(error) {
+                      console.error(error);
+                  });
+              }
+           }
+        });
+        
+        modalInstance.result.then(function() {
+            
         }, function() {
           console.info('Modal dismissed at: ' + new Date());
         });

--- a/client/views/games/games.sass
+++ b/client/views/games/games.sass
@@ -55,5 +55,11 @@
                 text-align: center
     .uib-accordion
         min-height: 200px
+    .ferry-row
+        background-color: #fcf
+    .route-row
+        background-color: #cff
+    .total-row
+        background-color: #ffc
 #games.games-detail
         min-height: 500px

--- a/client/views/games/modals/games-detail-turn-results-modal.jade
+++ b/client/views/games/modals/games-detail-turn-results-modal.jade
@@ -1,0 +1,41 @@
+#games
+    .modal-header
+        h3.modal-title Turn Results / Weekly Summary for {{turnResult.year}} - {{turnResult.week}}
+        a.pull-right(href="" ng-click="cancel()" style="margin-top: -25px;") X
+    .modal-body
+        .row
+            .col-xs-12.col-sm-6
+                h5 Ordinary Income Statement
+                table.table
+                    thead
+                        tr
+                            th
+                            th
+                            th Name
+                            th Passengers
+                            th Fares
+                            th Ferry Staffing
+                            th Route Staffing
+                            th Fuel Used
+                            th Fuel Cost
+                            th Maintenance
+                            th Profit
+                    tbody
+                        tr(ng-repeat="row in rows" ng-class="{ 'route-row': row.type == 'route', 'ferry-row': row.type == 'ferry', 'total-row': row.type == 'total' }")
+                            td
+                            td {{row.type}}
+                            td {{row.name}}
+                            td {{row.passengers}}
+                            td {{row.revenue}}
+                            td ttl ferry staff
+                            td ttl route staff
+                            td {{row.fuelUsed}}
+                            td {{row.fuelCost}}
+                            td maint
+                            td profit
+        .row
+            .col-xs-12.col-sm-6
+                h5 Non-Ordinary Income
+    .modal-footer
+        button.btn.btn-default(ng-click="cancel()") Close
+        

--- a/client/views/games/modals/games-detail-turn-results-modal.js
+++ b/client/views/games/modals/games-detail-turn-results-modal.js
@@ -1,0 +1,51 @@
+angular.module('py-ferry')
+.controller('GamesDetailTurnResultsModalInstanceCtrl', 
+['$scope', '$uibModalInstance', 'turnResult', '_', function ($scope, $uibModalInstance, turnResult, _) {
+
+  $scope.turnResult = turnResult;
+  console.log($scope.turnResult);
+  
+  $scope.rows = [];
+  
+  var totals = {};
+  totals.passengers = 0;
+  totals.fuelUsed = 0;
+  totals.revenue = 0;
+  $scope.turnResult.route_results.forEach(function(route) {
+      var routeTotals = {};
+      routeTotals.passengers = 0;
+      routeTotals.fuelUsed = 0;
+      routeTotals.revenue = 0;
+      route.ferry_results.forEach(function(ferry) {
+         var ferryRow = {};
+         ferryRow.type = 'ferry';
+         ferryRow.name = ferry.ferry.name;
+         
+         ferryRow.passengers = ferry.total_passengers + ferry.total_cars + ferry.total_trucks;
+         routeTotals.passengers += ferryRow.passengers;
+         totals.passengers += ferryRow.passengers;
+         
+         ferryRow.revenue = ferry.total_passengers * route.passenger_fare + ferry.total_cars * route.car_fare + ferry.total_trucks * route.truck_fare;
+         routeTotals.revenue += ferryRow.revenue;
+         totals.revenue += ferryRow.revenue;
+         
+         ferryRow.fuelUsed = ferry.fuel_used;
+         routeTotals.fuelUsed += ferryRow.fuelUsed;
+         totals.fuelUsed += ferryRow.fuelUsed;
+         
+         $scope.rows.push(ferryRow);
+      });
+      routeTotals.type = 'route';
+      routeTotals.name = route.first_terminal.name + ' to ' + route.second_terminal.name;
+      routeTotals.fuelCost = routeTotals.fuelUsed * $scope.turnResult.fuel_cost;
+      $scope.rows.push(routeTotals);
+  });
+  totals.type = 'total';
+  totals.name = 'Total';
+  $scope.rows.push(totals);
+
+
+  $scope.cancel = function () {
+    $uibModalInstance.dismiss('cancel');
+  };
+}]);

--- a/py_ferry/database.py
+++ b/py_ferry/database.py
@@ -225,6 +225,9 @@ class Route_Result(Base):
             "id": self.id,
             "first_terminal": self.first_terminal.as_dictionary(),
             "second_terminal": self.second_terminal.as_dictionary(),
+            "passenger_fare": self.passenger_fare,
+            "car_fare": self.car_fare,
+            "truck_fare": self.truck_fare,
             "ferry_results": [ferry_result.as_dictionary() for ferry_result in self.ferry_results] 
         }
         
@@ -251,7 +254,8 @@ class Turn_Result(Base):
             "game_id": self.game_id,
             "week": self.week,
             "year": self.year,
-            "route_results": [route_result.as_dictionary() for route_result in self.route_results]
+            "fuel_cost": self.fuel_cost,
+            "route_results": [route_result.as_dictionary() for route_result in self.route_results],
         }
         
     id = Column(Integer, primary_key = True)

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -822,7 +822,7 @@ class TestAPI(unittest.TestCase):
         
         self.assertEqual(data['current_week'], 2)
         
-        response = self.client.get('/api/games/' + str(game.id) + '/turn-results/' + str(game.current_week), 
+        response = self.client.get('/api/games/' + str(game.id) + '/turn_results/' + str(game.current_year) + '/week/' + str(game.current_week - 1), 
             headers = [
                 ('Accept', 'application/json'),
                 ('Authorization', 'JWT ' + token)
@@ -833,7 +833,6 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(response.mimetype, 'application/json')
         
         data = json.loads(response.data.decode('ascii'))
-        print(data)
         
         self.assertEqual(data['week'], 1)
         self.assertEqual(data['year'], 2000)


### PR DESCRIPTION
FE: get rid of console.logs
BE: fix some typos in todo notes I found
BE: refactor games_get_turn to account for both week and year for results fetching
FE: add model for TurnResults
FE: work on populating a table from unrolled rows coming from TurnResults
FE: add placeholder button to view results from the last turn
FE: build controller for opening the turnResults modal
BE: update the Route_Result class to add fares to as_dictionary method
BE: add fuel_cost to Turn_Result as_dictionary method, and add it to the turn_result record in the end_turn API endpoint
BE: update API integration test to accomodate for the changed endpoint route for end_turn
